### PR TITLE
feat: scale conquest speed around defense posts

### DIFF
--- a/resources/changelog.md
+++ b/resources/changelog.md
@@ -10,6 +10,7 @@
   → Each port you own now increases the gold per trade, counterbalancing the cap.
 - MIRVs have been nerfed
   → Expect less devastating multi-warhead nukes. Land in-between the fallout can be more quickly conquered.
+- Tiles without nearby defense posts are conquered faster, while tiles around a defense post are tougher to take.
 - Warships prioritize enemy transport ships over warships. Reload instantly after shooting a transport ship. (Evan)
 - Building discounts can only be used one time.
 - AI nukes now avoid SAM launchers

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -142,6 +142,8 @@ export interface Config {
   SiloCooldown(): number;
   defensePostDefenseBonus(): number;
   defensePostSpeedBonus(): number;
+  unprotectedDefenseBonus(): number;
+  unprotectedSpeedBonus(): number;
   falloutDefenseModifier(percentOfFallout: number): number;
   difficultyModifier(difficulty: Difficulty): number;
   warshipPatrolRange(): number;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -302,6 +302,14 @@ export class DefaultConfig implements Config {
     return 3;
   }
 
+  unprotectedDefenseBonus(): number {
+    return 0.5;
+  }
+
+  unprotectedSpeedBonus(): number {
+    return 0.5;
+  }
+
   playerTeams(): TeamCountConfig {
     return this._gameConfig.playerTeams ?? 0;
   }
@@ -584,6 +592,7 @@ export class DefaultConfig implements Config {
       default:
         throw new Error(`terrain type ${type} not supported`);
     }
+    let hasDefensePost = false;
     if (defender.isPlayer()) {
       for (const dp of gm.nearbyUnits(
         tileToConquer,
@@ -593,9 +602,14 @@ export class DefaultConfig implements Config {
         if (dp.unit.owner() === defender) {
           mag *= this.defensePostDefenseBonus();
           speed *= this.defensePostSpeedBonus();
+          hasDefensePost = true;
           break;
         }
       }
+    }
+    if (!hasDefensePost) {
+      mag *= this.unprotectedDefenseBonus();
+      speed *= this.unprotectedSpeedBonus();
     }
 
     if (gm.hasFallout(tileToConquer)) {


### PR DESCRIPTION
## Summary
- make unprotected tiles faster to conquer while fortified tiles resist longer
- expose config for adjusting unprotected defense and speed multipliers
- document new conquest behavior in changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68951bc225a08327b7bc53981df0f494