### PR TITLE
Add defense bonus map layer for defense posts

### DIFF
--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -2,8 +2,8 @@ import { PriorityQueue } from "@datastructures-js/priority-queue";
 import { Colord } from "colord";
 import { Theme } from "../../../core/configuration/Config";
 import { EventBus } from "../../../core/EventBus";
-import { Cell, PlayerType, UnitType } from "../../../core/game/Game";
-import { euclDistFN, TileRef } from "../../../core/game/GameMap";
+import { Cell, PlayerType } from "../../../core/game/Game";
+import { TileRef, euclDistFN } from "../../../core/game/GameMap";
 import { GameUpdateType } from "../../../core/game/GameUpdates";
 import { GameView, PlayerView } from "../../../core/game/GameView";
 import { UserSettings } from "../../../core/game/UserSettings";
@@ -81,23 +81,6 @@ export class TerritoryLayer implements Layer {
     }
     this.game.recentlyUpdatedTiles().forEach((t) => this.enqueueTile(t));
     const updates = this.game.updatesSinceLastTick();
-    const unitUpdates = updates !== null ? updates[GameUpdateType.Unit] : [];
-    unitUpdates.forEach((update) => {
-      if (update.unitType === UnitType.DefensePost) {
-        const tile = update.pos;
-        this.game
-          .bfs(tile, euclDistFN(tile, this.game.config().defensePostRange()))
-          .forEach((t) => {
-            if (
-              this.game.isBorder(t) &&
-              (this.game.ownerID(t) === update.ownerID ||
-                this.game.ownerID(t) === update.lastOwnerID)
-            ) {
-              this.enqueueTile(t);
-            }
-          });
-      }
-    });
 
     // Detect alliance mutations
     const myPlayer = this.game.myPlayer();
@@ -427,14 +410,7 @@ export class TerritoryLayer implements Layer {
         }
         this.paintTile(this.alternativeImageData, tile, alternativeColor, 255);
       }
-      if (
-        this.game.hasUnitNearby(
-          tile,
-          this.game.config().defensePostRange(),
-          UnitType.DefensePost,
-          owner.id(),
-        )
-      ) {
+      if (this.game.hasDefenseBonus(tile)) {
         const borderColors = this.theme.defendedBorderColors(owner);
         const x = this.game.x(tile);
         const y = this.game.y(tile);

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -584,18 +584,9 @@ export class DefaultConfig implements Config {
       default:
         throw new Error(`terrain type ${type} not supported`);
     }
-    if (defender.isPlayer()) {
-      for (const dp of gm.nearbyUnits(
-        tileToConquer,
-        gm.config().defensePostRange(),
-        UnitType.DefensePost,
-      )) {
-        if (dp.unit.owner() === defender) {
-          mag *= this.defensePostDefenseBonus();
-          speed *= this.defensePostSpeedBonus();
-          break;
-        }
-      }
+    if (gm.hasDefenseBonus(tileToConquer)) {
+      mag *= this.defensePostDefenseBonus();
+      speed *= this.defensePostSpeedBonus();
     }
 
     if (gm.hasFallout(tileToConquer)) {

--- a/src/core/execution/DefensePostExecution.ts
+++ b/src/core/execution/DefensePostExecution.ts
@@ -53,8 +53,10 @@ export class DefensePostExecution implements Execution {
         return;
       }
       this.post = this.player.buildUnit(UnitType.DefensePost, spawnTile, {});
+      this.mg.updateDefenseBonusAround(this.post.tile());
     }
     if (!this.post.isActive()) {
+      this.mg.updateDefenseBonusAround(this.post.tile());
       this.active = false;
       return;
     }

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -678,6 +678,7 @@ export interface Game extends GameMap {
   ): Array<{ unit: Unit; distSquared: number }>;
 
   addExecution(...exec: Execution[]): void;
+  updateDefenseBonusAround(tile: TileRef): void;
   displayMessage(
     message: string,
     type: MessageType,

--- a/src/core/game/GameMap.ts
+++ b/src/core/game/GameMap.ts
@@ -27,6 +27,8 @@ export interface GameMap {
   setOwnerID(ref: TileRef, playerId: number): void;
   hasFallout(ref: TileRef): boolean;
   setFallout(ref: TileRef, value: boolean): void;
+  hasDefenseBonus(ref: TileRef): boolean;
+  setDefenseBonus(ref: TileRef, value: boolean): void;
   isOnEdgeOfMap(ref: TileRef): boolean;
   isBorder(ref: TileRef): boolean;
   neighbors(ref: TileRef): TileRef[];

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -633,6 +633,12 @@ export class GameView implements GameMap {
   setFallout(ref: TileRef, value: boolean): void {
     return this._map.setFallout(ref, value);
   }
+  hasDefenseBonus(ref: TileRef): boolean {
+    return this._map.hasDefenseBonus(ref);
+  }
+  setDefenseBonus(ref: TileRef, value: boolean): void {
+    return this._map.setDefenseBonus(ref, value);
+  }
   isBorder(ref: TileRef): boolean {
     return this._map.isBorder(ref);
   }
@@ -677,6 +683,9 @@ export class GameView implements GameMap {
   }
   numTilesWithFallout(): number {
     return this._map.numTilesWithFallout();
+  }
+  updateDefenseBonusAround(_tile: TileRef): void {
+    /* no-op on client */
   }
   gameID(): GameID {
     return this._gameID;


### PR DESCRIPTION
## Summary
- mark tiles within defense post range on a dedicated map layer
- slow conquest on defended tiles and render fortified borders

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_689620a7529c8327be67559ea986f2d0